### PR TITLE
Update 1.0.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.4
 
 # Mod Properties
-	mod_version = 1.0.2
+	mod_version = 1.0.3
 	maven_group = io.github.opekope2
 	archives_base_name = optigui
 

--- a/src/main/java/opekope2/optigui/callback/UseCallback.java
+++ b/src/main/java/opekope2/optigui/callback/UseCallback.java
@@ -16,14 +16,18 @@ import opekope2.optigui.Replacer;
 public final class UseCallback implements UseBlockCallback, UseEntityCallback {
     @Override
     public ActionResult interact(PlayerEntity player, World world, Hand hand, BlockHitResult hitResult) {
-        Replacer.instance.useBlock(hitResult.getBlockPos());
+        if (world.isClient) {
+            Replacer.instance.useBlock(hitResult.getBlockPos());
+        }
         return ActionResult.PASS;
     }
 
     @Override
     public ActionResult interact(PlayerEntity player, World world, Hand hand, Entity entity,
             @Nullable EntityHitResult hitResult) {
-        Replacer.instance.useEntity(entity);
+        if (world.isClient) {
+            Replacer.instance.useEntity(entity);
+        }
         return ActionResult.PASS;
     }
 }

--- a/src/main/java/opekope2/optigui/optifinecompat/OptifineProperties.java
+++ b/src/main/java/opekope2/optigui/optifinecompat/OptifineProperties.java
@@ -249,7 +249,7 @@ public final class OptifineProperties {
             }
         }
 
-        /*if (nameMatcher != null) {
+        if (nameMatcher != null) {
             BlockEntity entity = mc.world.getBlockEntity(pos);
             if (entity != null && entity instanceof Nameable nameable) {
                 if (nameable.hasCustomName()) {
@@ -261,7 +261,7 @@ public final class OptifineProperties {
                     return false;
                 }
             }
-        }*/
+        }
 
         BlockState state = mc.world.getBlockState(pos);
         Identifier blockId = Registry.BLOCK.getId(state.getBlock());

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "optigui",
-  "version": "1.0.2",
+  "version": "1.0.3",
 
   "name": "OptiGUI",
   "description": "A drop-in replacement for OptiFine custom GUIs",


### PR DESCRIPTION
* Fix block entity name matching
* Fix a critical bug where the single player server messes with the name matcher. This mod should only have effect on the client side (because the server renders nothing). Previously, the right click callback ran on both the client and the server side, causing the last clicked block to be a server block, feeding it to on a client side world function (because the client and the server are in the same process). I can't imagine how it could work.